### PR TITLE
Add marketplace.json catalog and update plugin discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,24 @@ Data foundations that every financial system depends on.
 
 ---
 
+## Marketplace Config
+
+`marketplace.json` is a machine-readable catalog of every plugin in this repo. It
+aggregates each plugin's name, description, version, dependencies, skill list, and
+tags into a single document for use by tooling, CI, and the `install.sh --list`
+command.
+
+```bash
+# Inspect the full catalog
+cat marketplace.json | python3 -m json.tool
+```
+
+Each entry mirrors the corresponding `plugin.json` but is consolidated at the repo
+level, making it the authoritative source for plugin discovery without requiring
+directory traversal.
+
+---
+
 ## Installation
 
 ### Prerequisites
@@ -257,6 +275,7 @@ finance_skills/
 ├── README.md
 ├── PLAN.md                    # Architecture and implementation roadmap
 ├── CLAUDE.md                  # Claude Code project instructions
+├── marketplace.json           # Machine-readable catalog of all plugins
 ├── install.sh                 # Plugin installer
 └── plugins/
     ├── core/

--- a/install.sh
+++ b/install.sh
@@ -53,22 +53,44 @@ EOF
 }
 
 list_plugins() {
+  local marketplace="$SCRIPT_DIR/marketplace.json"
   echo "Available plugins:"
   echo ""
-  for plugin in "${ALL_PLUGINS[@]}"; do
-    manifest="$PLUGINS_DIR/$plugin/plugin.json"
-    if [[ -f "$manifest" ]]; then
-      description=$(python3 -c "import json,sys; d=json.load(open('$manifest')); print(d.get('description',''))" 2>/dev/null || echo "")
-      skill_count=$(ls "$PLUGINS_DIR/$plugin/skills/" 2>/dev/null | wc -l | tr -d ' ')
-      echo "  $plugin ($skill_count skills)"
-      echo "    $description"
-      deps="${PLUGIN_DEPS[$plugin]:-}"
-      if [[ -n "$deps" ]]; then
-        echo "    Dependencies: $deps"
+  if [[ -f "$marketplace" ]]; then
+    python3 - "$marketplace" <<'PYEOF'
+import json, sys
+
+with open(sys.argv[1]) as f:
+    catalog = json.load(f)
+
+for plugin in catalog.get("plugins", []):
+    name = plugin.get("name", "")
+    description = plugin.get("description", "")
+    skill_count = plugin.get("skillCount", len(plugin.get("skills", [])))
+    deps = plugin.get("dependencies", [])
+    print(f"  {name} ({skill_count} skills)")
+    print(f"    {description}")
+    if deps:
+        print(f"    Dependencies: {' '.join(deps)}")
+    print()
+PYEOF
+  else
+    # Fallback: read individual plugin.json files
+    for plugin in "${ALL_PLUGINS[@]}"; do
+      manifest="$PLUGINS_DIR/$plugin/plugin.json"
+      if [[ -f "$manifest" ]]; then
+        description=$(python3 -c "import json,sys; d=json.load(open('$manifest')); print(d.get('description',''))" 2>/dev/null || echo "")
+        skill_count=$(ls "$PLUGINS_DIR/$plugin/skills/" 2>/dev/null | wc -l | tr -d ' ')
+        echo "  $plugin ($skill_count skills)"
+        echo "    $description"
+        deps="${PLUGIN_DEPS[$plugin]:-}"
+        if [[ -n "$deps" ]]; then
+          echo "    Dependencies: $deps"
+        fi
+        echo ""
       fi
-      echo ""
-    fi
-  done
+    done
+  fi
 }
 
 install_plugin() {

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,172 @@
+{
+  "name": "finance-skills",
+  "version": "1.0.0",
+  "description": "Claude Code skill plugins for financial services — 81 skills across 7 domain plugins covering investment management, compliance, advisory practice, trading, and operations.",
+  "plugins": [
+    {
+      "name": "core",
+      "version": "1.0.0",
+      "description": "Mathematical and statistical foundations required by all other plugins. Always installed — every plugin implicitly depends on core.",
+      "path": "plugins/core",
+      "dependencies": [],
+      "skillCount": 3,
+      "skills": [
+        "return-calculations",
+        "time-value-of-money",
+        "statistics-fundamentals"
+      ],
+      "tags": ["math", "statistics", "foundations"],
+      "scripts": true
+    },
+    {
+      "name": "wealth-management",
+      "version": "1.0.0",
+      "description": "Investment knowledge for personal and institutional wealth management. Covers risk measurement, asset classes, valuation, portfolio construction, policy and planning, personal finance, behavioral finance, and reporting.",
+      "path": "plugins/wealth-management",
+      "dependencies": ["core"],
+      "skillCount": 31,
+      "skills": [
+        "historical-risk",
+        "performance-metrics",
+        "forward-risk",
+        "volatility-modeling",
+        "equities",
+        "fixed-income-sovereign",
+        "fixed-income-municipal",
+        "fixed-income-corporate",
+        "fixed-income-structured",
+        "commodities",
+        "real-assets",
+        "alternatives",
+        "fund-vehicles",
+        "currencies-and-fx",
+        "digital-assets",
+        "quantitative-valuation",
+        "qualitative-valuation",
+        "diversification",
+        "asset-allocation",
+        "bet-sizing",
+        "rebalancing",
+        "investment-policy",
+        "tax-efficiency",
+        "performance-attribution",
+        "debt-management",
+        "lending",
+        "emergency-fund",
+        "savings-goals",
+        "liquidity-management",
+        "finance-psychology",
+        "performance-reporting"
+      ],
+      "tags": ["investment", "portfolio", "risk", "personal-finance", "asset-classes"],
+      "scripts": true
+    },
+    {
+      "name": "compliance",
+      "version": "1.0.0",
+      "description": "US securities regulatory guidance for broker-dealers and investment advisers. Covers FINRA, SEC, ERISA, FinCEN, and CFA Institute GIPS requirements. Guidance-only — no Python scripts.",
+      "path": "plugins/compliance",
+      "dependencies": ["core"],
+      "skillCount": 16,
+      "skills": [
+        "investment-suitability",
+        "know-your-customer",
+        "anti-money-laundering",
+        "reg-bi",
+        "fiduciary-standards",
+        "fee-disclosure",
+        "advice-standards",
+        "sales-practices",
+        "advertising-compliance",
+        "client-disclosures",
+        "conflicts-of-interest",
+        "books-and-records",
+        "regulatory-reporting",
+        "gips-compliance",
+        "privacy-data-security",
+        "examination-readiness"
+      ],
+      "tags": ["compliance", "regulatory", "SEC", "FINRA", "ERISA", "AML"],
+      "scripts": false
+    },
+    {
+      "name": "advisory-practice",
+      "version": "1.0.0",
+      "description": "Advisor-facing systems and workflows. Teaches Claude how advisor platforms work so it can help design, evaluate, or integrate with them. Covers the full advisor workflow from onboarding through reporting.",
+      "path": "plugins/advisory-practice",
+      "dependencies": ["core", "wealth-management"],
+      "skillCount": 10,
+      "skills": [
+        "client-onboarding",
+        "crm-client-lifecycle",
+        "portfolio-management-systems",
+        "order-management-advisor",
+        "financial-planning-integration",
+        "proposal-generation",
+        "advisor-dashboards",
+        "next-best-action",
+        "fee-billing",
+        "client-reporting-delivery"
+      ],
+      "tags": ["advisor", "wealth-management", "front-office", "crm", "billing"],
+      "scripts": false
+    },
+    {
+      "name": "trading-operations",
+      "version": "1.0.0",
+      "description": "Order lifecycle from entry through settlement, plus operational and counterparty risk. Serves advisor, algorithmic, and client-direct trading contexts.",
+      "path": "plugins/trading-operations",
+      "dependencies": ["core"],
+      "skillCount": 9,
+      "skills": [
+        "order-lifecycle",
+        "trade-execution",
+        "pre-trade-compliance",
+        "post-trade-compliance",
+        "settlement-clearing",
+        "exchange-connectivity",
+        "margin-operations",
+        "operational-risk",
+        "counterparty-risk"
+      ],
+      "tags": ["trading", "order-management", "settlement", "execution", "risk"],
+      "scripts": false
+    },
+    {
+      "name": "client-operations",
+      "version": "1.0.0",
+      "description": "Back-office account operations and servicing workflows. Covers the full account lifecycle from opening through maintenance, transfers, reconciliation, and corporate actions.",
+      "path": "plugins/client-operations",
+      "dependencies": ["core"],
+      "skillCount": 8,
+      "skills": [
+        "account-opening-workflow",
+        "account-opening-compliance",
+        "account-maintenance",
+        "account-transfers",
+        "reconciliation",
+        "corporate-actions",
+        "stp-automation",
+        "workflow-automation"
+      ],
+      "tags": ["back-office", "account-management", "transfers", "reconciliation", "corporate-actions"],
+      "scripts": false
+    },
+    {
+      "name": "data-integration",
+      "version": "1.0.0",
+      "description": "Data foundations that every financial system depends on. Covers reference data management, market data feeds, integration patterns for financial systems, and data quality governance.",
+      "path": "plugins/data-integration",
+      "dependencies": ["core"],
+      "skillCount": 4,
+      "skills": [
+        "reference-data",
+        "market-data",
+        "integration-patterns",
+        "data-quality"
+      ],
+      "tags": ["data", "reference-data", "market-data", "integration", "data-quality"],
+      "scripts": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Introduces a machine-readable plugin catalog (`marketplace.json`) to centralize plugin metadata and updates the installation script to use it for plugin discovery and listing.

## Key Changes

- **Added `marketplace.json`**: A consolidated catalog containing metadata for all 7 plugins (81 skills total) including name, version, description, dependencies, skill lists, and tags. Serves as the authoritative source for plugin discovery without requiring directory traversal.

- **Updated `install.sh list_plugins()`**: Modified to read from `marketplace.json` when available, with a fallback to the original directory-based discovery method. Uses Python to parse the JSON catalog and display plugin information in a consistent format.

- **Updated `README.md`**: Added "Marketplace Config" section documenting the purpose and usage of `marketplace.json`, including an example command to inspect the catalog.

## Implementation Details

- The `marketplace.json` structure mirrors individual `plugin.json` files but consolidates all plugins at the repo level
- Plugin listing now prioritizes the marketplace catalog for faster, more reliable discovery
- Fallback mechanism ensures backward compatibility if `marketplace.json` is unavailable
- All 7 plugins are cataloged with accurate skill counts and dependency declarations (e.g., wealth-management depends on core, advisory-practice depends on both core and wealth-management)

https://claude.ai/code/session_01QUgHwKpbccLfqeXWFskCNn